### PR TITLE
Fixed footer on 404-page

### DIFF
--- a/statamic/resources/views/errors/404.antlers.html
+++ b/statamic/resources/views/errors/404.antlers.html
@@ -2,6 +2,7 @@
   body {
     background-color: var(--purple_darkViolett);
     height: 100vh;
+    overflow-y: overlay;
   }
 
   #error-image-wrapper {
@@ -49,6 +50,17 @@
     #right-dark-fern {
       display: none;
     }
+  }
+
+  .footer {
+    z-index: 1001;
+  }
+
+  #footer_nav {
+    padding-left: 10px;
+    border-radius: 10px;
+    backdrop-filter: blur(4px);
+    background-color: #4C498166; /* var(--purple_darkViolett) with 40% alpha */
   }
 </style>
 


### PR DESCRIPTION
+ Previously, the leftmost part of the footer was blocked by the fern images.
+ Also made sure the fern doesn't overlap the vertical scrollbar.

## Before
![before](https://user-images.githubusercontent.com/20467351/159916105-7fca44f0-18e2-4fa7-a35e-5d863fedbe18.png)

## After
![after](https://user-images.githubusercontent.com/20467351/159916116-38ca33d0-4558-4198-8b39-f9ff1f3784a0.png)

